### PR TITLE
fix error TS1192.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
 	import Vue = require('vue')
 	const value: Vue.ComponentOptions<Vue>
-	export = value
+	export default value
 }


### PR DESCRIPTION
fix `error TS1192: Module ''*.vue'' has no default export` when using .vue file in this way: `<script src="xxx.ts"></script>`

I don't think this PR is ok to merge. But this problem confused me for few hours. So maybe it can help others. Hope there is a better solution :-)